### PR TITLE
Update TfsClientProvider.cs

### DIFF
--- a/Colyar.SourceControl.MicrosoftTfsClient/TfsClientProvider.cs
+++ b/Colyar.SourceControl.MicrosoftTfsClient/TfsClientProvider.cs
@@ -189,13 +189,21 @@ namespace Colyar.SourceControl.MicrosoftTfsClient
             // Rename file.
             else if ((change.ChangeType & ChangeType.Rename) == ChangeType.Rename)
             {
-                RenameFile(changeset, change);
-
-                //"Edit, Rename" is possible and should be handled 
-                if ((change.ChangeType & ChangeType.Edit) == ChangeType.Edit)
-                    EditFile(changeset, change);
+            	if ((change.ChangeType & ChangeType.Delete) == ChangeType.Delete)
+                {
+                    // "Delete, Rename" is possible and should be handled
+                    DeleteFile(changeset, change);
+                }
+                else
+                {
+	            RenameFile(changeset, change);
+	
+	            //"Edit, Rename" is possible and should be handled 
+	            if ((change.ChangeType & ChangeType.Edit) == ChangeType.Edit)
+	                EditFile(changeset, change);
+                }
             }
-
+            
             // Branch file.
             else if ((change.ChangeType & ChangeType.Branch) == ChangeType.Branch)
                 BranchFile(changeset, change);

--- a/Colyar.SourceControl.OpenTfsClient/TfsClientProvider.cs
+++ b/Colyar.SourceControl.OpenTfsClient/TfsClientProvider.cs
@@ -195,11 +195,19 @@ namespace Colyar.SourceControl.OpenTfsClient
             // Rename file.
             else if ((change.ChangeType & ChangeType.Rename) == ChangeType.Rename)
             {
-                RenameFile(changeset, change);
-
-                //"Edit, Rename" is possible and should be handled 
-                if ((change.ChangeType & ChangeType.Edit) == ChangeType.Edit)
-                    EditFile(changeset, change);
+            	if ((change.ChangeType & ChangeType.Delete) == ChangeType.Delete)
+                {
+                    // "Delete, Rename" is possible and should be handled
+                    DeleteFile(changeset, change);
+                }
+                else
+                {
+	            RenameFile(changeset, change);
+	
+	            //"Edit, Rename" is possible and should be handled 
+	            if ((change.ChangeType & ChangeType.Edit) == ChangeType.Edit)
+	                EditFile(changeset, change);
+                }
             }
 
             // Branch file.


### PR DESCRIPTION
I ran into a case where the edit+rename flags where set on a file and the code crashed here. The above change fixed the problem. This was TFS 2008 and I think it happened because a folder was renamed and a file in the folder was deleted in the same change set.
One could possibly fix this more elegantly by executing the delete block before the rename block, but I fear this could have other consequences.
